### PR TITLE
Make the saturation configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,13 +29,19 @@ void setup() {
 
 ## Plugin properties
 
-The plugin provides the `LEDBreatheEffect` object, which has a single property:
+The plugin provides the `LEDBreatheEffect` object, which has two properties:
 
 ### `.hue`
 
 > The hue of the breathe effect.
 >
 > Defaults to 170.
+
+### `.saturation`
+
+> The saturation of the breathe effect.
+>
+> Defaults to 255.
 
 ## Dependencies
 

--- a/src/Kaleidoscope-LEDEffect-Breathe.cpp
+++ b/src/Kaleidoscope-LEDEffect-Breathe.cpp
@@ -2,7 +2,7 @@
 
 namespace kaleidoscope {
 void LEDBreatheEffect::update(void) {
-  cRGB color = breath_compute(hue);
+  cRGB color = breath_compute(hue, saturation);
   ::LEDControl.set_all_leds_to(color);
 }
 }

--- a/src/Kaleidoscope-LEDEffect-Breathe.h
+++ b/src/Kaleidoscope-LEDEffect-Breathe.h
@@ -9,6 +9,7 @@ class LEDBreatheEffect : public LEDMode {
   LEDBreatheEffect(void) {}
 
   uint8_t hue = 170;
+  uint8_t saturation = 255;
 
  protected:
   void update(void) final;


### PR DESCRIPTION
Allows for possibilities like white, antique white, lighter variants of other colors. This is an extremely simple change, because the underlying library already supports this with no changes.

I have tested it, it works as expected.

I really just wanted white, is why I did this.