### PR TITLE
Limit refresh rate and don't update on every cycle

### DIFF
--- a/src/Kaleidoscope-LEDEffect-Breathe.cpp
+++ b/src/Kaleidoscope-LEDEffect-Breathe.cpp
@@ -1,7 +1,13 @@
 #include "Kaleidoscope-LEDEffect-Breathe.h"
+#define UPDATE_INTERVAL 50  // milliseconds between two LED updates to avoid overloading; 20 fps
 
 namespace kaleidoscope {
 void LEDBreatheEffect::update(void) {
+  uint16_t now = millis();
+  if ((now - last_update) < UPDATE_INTERVAL)
+    return;
+  last_update = now;
+
   cRGB color = breath_compute(hue, saturation);
   ::LEDControl.set_all_leds_to(color);
 }

--- a/src/Kaleidoscope-LEDEffect-Breathe.h
+++ b/src/Kaleidoscope-LEDEffect-Breathe.h
@@ -13,6 +13,9 @@ class LEDBreatheEffect : public LEDMode {
 
  protected:
   void update(void) final;
+
+ private:
+  uint16_t last_update = 0;
 };
 }
 


### PR DESCRIPTION
The breathe function is somewhat costly and is found to cause drag in
mouse movements. This commit seeks to fix this problem.

It is observed that the function doesn't change output value for every
input value. It only causes the output brightness to increase by 128
units (from 80 to 208) over 2048 ms (the half-period). This means 1 unit
for 16 ms. But a brightness change of 1 unit doesn't mean much visually
especially considering persistence of vision. A refresh rate of 20 per
second ie 50 ms between LED updates is found to be sufficient to avoid
the drag effect while maintaining smoothness in brightness changes.